### PR TITLE
Replace pip dependencies by apt dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
                 <strong>1)</strong> Install the required dependencies:
             </p>
             <pre>
-sudo apt install git curl python3-pip exuberant-ctags ack-grep
-sudo pip3 install pynvim flake8 pylint isort</pre>
+sudo apt install git curl exuberant-ctags ack-grep python3-nvim python3-flake8 pylint3 python3-isort
+</pre>
             </p>
             <p>
                 <strong>2)</strong> Download the <a href="https://raw.github.com/fisadev/fisa-vim-config/v12.0.1/config.vim">config file</a> 
@@ -100,8 +100,8 @@ sudo pip3 install pynvim flake8 pylint isort</pre>
                 <strong>1)</strong> Install the required dependencies:
             </p>
               <pre>
-sudo apt install git curl python3-pip exuberant-ctags ack-grep
-sudo pip3 install pynvim flake8 pylint isort</pre>
+sudo apt install git curl exuberant-ctags ack-grep python3-nvim python3-flake8 pylint3 python3-isort
+</pre>
             </p>
             <p>
                 <strong>2)</strong> Download the <a href="https://raw.github.com/fisadev/fisa-vim-config/v12.0.1/config.vim">config file</a> 


### PR DESCRIPTION
No `sudo pip` is needed anymore. Just tested on a fresh machine and everything is working perfectly :D